### PR TITLE
Create a command to start news-fragments plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,6 @@ dist/
 tmp/
 temp/
 
+.vscode/
+
 # End of https://www.gitignore.io/api/node

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "standard.enable": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -863,9 +863,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -879,9 +879,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -4480,14 +4480,13 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nise": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.2.tgz",
-      "integrity": "sha512-ALDnm0pTTyeGdbg5FCpWGd58Nmp3qO8d8x+dU2Fw8lApeJTEBSjkBZZM4S8t6GpKh+czxkfM/TKxpRMroZzwOg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^6.0.0",
-        "@sinonjs/formatio": "^5.0.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
@@ -6147,15 +6146,15 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
-      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.1.tgz",
+      "integrity": "sha512-iTTyiQo5T94jrOx7X7QLBZyucUJ2WvL9J13+96HMfm2CGoJYbIPqRfl6wgNcqmzk0DI28jeGx5bUTXizkrqBmg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/fake-timers": "^6.0.0",
-        "@sinonjs/formatio": "^5.0.0",
-        "@sinonjs/samsam": "^5.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
         "diff": "^4.0.2",
         "nise": "^4.0.1",
         "supports-color": "^7.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4392,6 +4392,11 @@
       "integrity": "sha512-Yp4o3/ZA15wsXqJTT+R+9w2AYIkD1i80Lds47wDbuUhOvQvm+O2EfjFZSz0pMgZZSPHRhGxgcd2+GL4+jZMtdw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "mri": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2574,6 +2574,16 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4050,6 +4060,14 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -6910,6 +6928,11 @@
       "requires": {
         "os-name": "^3.1.0"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,20 +29,20 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "husky": "^4.2.3",
     "jest": "^25.1.0",
     "mock-fs": "^4.11.0",
     "prettier": "^1.19.1",
+    "pretty-quick": "^2.0.1",
     "semver": "^7.1.3",
-    "sinon": "^9.0.0",
-    "husky": "^4.2.3",
-    "pretty-quick": "^2.0.1"
+    "sinon": "^9.0.1"
   },
   "dependencies": {
     "@hapi/joi": "^17.1.0",
     "fs-extra": "^8.1.0",
     "handlebars": "^4.7.3",
     "moment": "^2.24.0",
-    "release-it": "^12.6.2"
+    "release-it": "^13.0.2"
   },
   "engines": {
     "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@hapi/joi": "^17.1.0",
     "fs-extra": "^8.1.0",
     "handlebars": "^4.7.3",
+    "moment": "^2.24.0",
     "release-it": "^12.6.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,9 @@
   },
   "dependencies": {
     "@hapi/joi": "^17.1.0",
-    "release-it": "^13.0.2",
-    "handlebars": "^4.7.3"
+    "fs-extra": "^8.1.0",
+    "handlebars": "^4.7.3",
+    "release-it": "^12.6.2"
   },
   "engines": {
     "node": ">=8"

--- a/src/build-template.js
+++ b/src/build-template.js
@@ -1,4 +1,4 @@
-const fs = require("fs");
+const fs = require("fs-extra");
 const Handlebars = require("handlebars");
 
 module.exports.renderTemplate = function(changelogTemplate, data) {

--- a/src/build-template.js
+++ b/src/build-template.js
@@ -1,5 +1,6 @@
 const fs = require("fs-extra");
 const Handlebars = require("handlebars");
+const moment = require("moment");
 
 module.exports.renderTemplate = function(changelogTemplate, data) {
   const compiledTemplate = Handlebars.compile(changelogTemplate);
@@ -16,4 +17,16 @@ module.exports.saveChangelogToFile = function(filePath, renderedTemplate) {
   fs.writeSync(fileDescriptor, oldData, 0, oldData.length, newData.length);
 
   fs.closeSync(fileDescriptor);
+};
+
+module.exports.generateTemplateData = function(
+  newVersion,
+  dateFormat,
+  fragments
+) {
+  return {
+    newVersion,
+    bumpDate: moment().format(dateFormat),
+    fragments
+  };
 };

--- a/src/config.js
+++ b/src/config.js
@@ -20,9 +20,9 @@ const schema = Joi.object({
 const changelogTemplate = `# [{{newVersion}}] - ({{bumpDate}})
 {{#fragments}}
 ## {{title}}
-{{#fragmentEntries}}
-* {{fragment}}
-{{/fragmentEntries}}
+{{#each fragmentEntries}}
+* {{this}}
+{{/each}}
 {{/fragments}}
 `;
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,7 @@
 const Joi = require("@hapi/joi");
 
+const RELEASE_IT = "release-it";
+
 const fragmentsTypesSchema = Joi.object({
   title: Joi.string().required(),
   extension: Joi.string().required()
@@ -48,4 +50,16 @@ module.exports.buildConfig = function(config) {
   }
 
   return newsFragmentConfiguration;
+};
+
+module.exports.retrieveUserConfig = function(pjson, name) {
+  if (
+    pjson.hasOwnProperty(RELEASE_IT) &&
+    pjson[RELEASE_IT].hasOwnProperty("plugins") &&
+    pjson[RELEASE_IT]["plugins"].hasOwnProperty(name)
+  ) {
+    return pjson[RELEASE_IT]["plugins"][name];
+  }
+
+  return null;
 };

--- a/src/file.js
+++ b/src/file.js
@@ -18,7 +18,7 @@ module.exports.getFragmentsFilesByFragmentType = function(
 
 module.exports.getFragmentsContent = function(fragmentsFiles) {
   return fragmentsFiles.map(file => {
-    return fs.readFileSync(file, "utf8");
+    return fs.readFileSync(file, "utf8").replace("\n", "");
   });
 };
 

--- a/src/file.js
+++ b/src/file.js
@@ -1,4 +1,4 @@
-var fs = require("fs");
+var fs = require("fs-extra");
 var path = require("path");
 
 module.exports.getFragmentsFilesByFragmentType = function(

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,15 @@
+const fs = require("fs-extra");
+const path = require("path");
+
+module.exports.checkChangelogFile = function(changelogFile) {
+  if (!fs.existsSync(changelogFile)) {
+    fs.writeFileSync(changelogFile, "");
+  }
+};
+
+module.exports.checkFragmentsFolder = function(fragmentsFolder) {
+  const fragmentsPath = path.join(fragmentsFolder, ".gitkeep");
+  if (!fs.existsSync(fragmentsPath)) {
+    fs.outputFileSync(fragmentsPath, "");
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,10 @@
+const {
+  generateTemplateData,
+  renderTemplate,
+  saveChangelogToFile
+} = require("./build-template");
 const { buildConfig, retrieveUserConfig } = require("./config");
+const { deleteFragmentsFiles } = require("./file");
 const { checkChangelogFile, checkFragmentsFolder } = require("./helpers");
 const {
   getFragmentsFilesByFragmentType,
@@ -48,6 +54,18 @@ class NewsFragments extends Plugin {
       }
     });
   }
+  afterRelease() {
+    const templateData = generateTemplateData(
+      this.getLatestVersion(),
+      this.baseConfig.dateFormat,
+      this.fragmentsToBurn
+    );
+    const renderedTemplate = renderTemplate(
+      this.baseConfig.changelogTemplate,
+      templateData
+    );
+    saveChangelogToFile(this.baseConfig.changelogFile, renderedTemplate);
+    deleteFragmentsFiles(this.fragmentsToDelete);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const pjson = require("../package.json");
 
 class NewsFragments extends Plugin {
   getName() {
-    return "@grupoboticario/newsfragments";
+    return "@grupoboticario/news-fragments";
   }
   getLatestVersion() {
     return pjson.version;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 const { buildConfig, retrieveUserConfig } = require("./config");
 const { checkChangelogFile, checkFragmentsFolder } = require("./helpers");
+const {
+  getFragmentsFilesByFragmentType,
+  getFragmentsContent
+} = require("./file");
 const { Plugin } = require("release-it");
 const pjson = require("../package.json");
 
@@ -17,6 +21,33 @@ class NewsFragments extends Plugin {
   init() {
     const userConfig = retrieveUserConfig(pjson, this.getName());
     this.baseConfig = buildConfig(userConfig);
+
+    this.start();
+
+    this.fragmentsToBurn = [];
+    this.fragmentsToDelete = [];
+
+    this.baseConfig.fragmentsTypes.forEach(fragmentType => {
+      const fragmentsEncountered = getFragmentsFilesByFragmentType(
+        this.baseConfig.fragmentsFolder,
+        fragmentType.extension
+      );
+
+      this.fragmentsToDelete = [
+        ...this.fragmentsToDelete,
+        ...fragmentsEncountered
+      ];
+
+      const fragmentEntries = getFragmentsContent(fragmentsEncountered);
+
+      if (fragmentEntries.length > 0) {
+        this.fragmentsToBurn.push({
+          title: fragmentType.title,
+          fragmentEntries
+        });
+      }
+    });
+  }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class NewsFragments extends Plugin {
   afterRelease() {
     const templateData = generateTemplateData(
       this.getLatestVersion(),
-      this.baseConfig.dateFormat,
+      this.baseConfig.changelogDateFormat,
       this.fragmentsToBurn
     );
     const renderedTemplate = renderTemplate(

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const { buildConfig, retrieveUserConfig } = require("./config");
 const { Plugin } = require("release-it");
 const pjson = require("../package.json");
 
@@ -7,6 +8,10 @@ class NewsFragments extends Plugin {
   }
   getLatestVersion() {
     return pjson.version;
+  }
+  init() {
+    const userConfig = retrieveUserConfig(pjson, this.getName());
+    this.baseConfig = buildConfig(userConfig);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const { buildConfig, retrieveUserConfig } = require("./config");
+const { checkChangelogFile, checkFragmentsFolder } = require("./helpers");
 const { Plugin } = require("release-it");
 const pjson = require("../package.json");
 
@@ -8,6 +9,10 @@ class NewsFragments extends Plugin {
   }
   getLatestVersion() {
     return pjson.version;
+  }
+  start() {
+    checkChangelogFile(this.baseConfig.changelogFile);
+    checkFragmentsFolder(this.baseConfig.fragmentsFolder);
   }
   init() {
     const userConfig = retrieveUserConfig(pjson, this.getName());

--- a/tests/build-template.test.js
+++ b/tests/build-template.test.js
@@ -16,17 +16,12 @@ const mockData = {
   fragments: [
     {
       title: "Feature",
-      fragmentEntries: [
-        { fragment: "Implements JWT handler" },
-        { fragment: "Add x-request-id to logger" }
-      ]
+      fragmentEntries: ["Implements JWT handler", "Add x-request-id to logger"]
     },
     {
       title: "Bugfix",
       fragmentEntries: [
-        {
-          fragment: "Update auth function to work properly when JWT is null"
-        }
+        "Update auth function to work properly when JWT is null"
       ]
     }
   ]

--- a/tests/build-template.test.js
+++ b/tests/build-template.test.js
@@ -4,7 +4,7 @@ const {
 } = require("../src/build-template");
 const { buildConfig } = require("../src/config");
 
-const fs = require("fs");
+const fs = require("fs-extra");
 const mockFs = require("mock-fs");
 
 let changelogTemplate;

--- a/tests/build-template.test.js
+++ b/tests/build-template.test.js
@@ -1,18 +1,22 @@
 const {
   renderTemplate,
+  generateTemplateData,
   saveChangelogToFile
 } = require("../src/build-template");
 const { buildConfig } = require("../src/config");
 
 const fs = require("fs-extra");
 const mockFs = require("mock-fs");
+const moment = require("moment");
 
 let changelogTemplate;
 let changelogFile;
 
+const TODAY = moment().format("YYYY-MM-DD");
+
 const mockData = {
   newVersion: "0.0.2",
-  bumpDate: "20/02/2020",
+  bumpDate: TODAY,
   fragments: [
     {
       title: "Feature",
@@ -27,7 +31,7 @@ const mockData = {
   ]
 };
 
-const expectedOutput = `# [0.0.2] - (20/02/2020)
+const expectedOutput = `# [0.0.2] - (${TODAY})
 ## Feature
 * Implements JWT handler
 * Add x-request-id to logger
@@ -57,7 +61,7 @@ test("should write in an empty file", () => {
   const renderedTemplate = renderTemplate(changelogTemplate, mockData);
   saveChangelogToFile(changelogFile, renderedTemplate);
   expect(fs.readFileSync(changelogFile).toString())
-    .toStrictEqual(`# [0.0.2] - (20/02/2020)
+    .toStrictEqual(`# [0.0.2] - (${TODAY})
 ## Feature
 * Implements JWT handler
 * Add x-request-id to logger
@@ -73,11 +77,29 @@ test("should prepend in a file with content", () => {
   const renderedTemplate = renderTemplate(changelogTemplate, mockData);
   saveChangelogToFile(changelogFile, renderedTemplate);
   const data = fs.readFileSync(changelogFile);
-  expect(data.toString()).toStrictEqual(`# [0.0.2] - (20/02/2020)
+  expect(data.toString()).toStrictEqual(`# [0.0.2] - (${TODAY})
 ## Feature
 * Implements JWT handler
 * Add x-request-id to logger
 ## Bugfix
 * Update auth function to work properly when JWT is null
 matheuszin_reidelas2011@hotmail.com`);
+});
+
+test("should generate the data to use in template", () => {
+  const fakeFragments = [
+    {
+      title: "Feature",
+      fragmentEntries: ["Implements JWT handler", "Add x-request-id to logger"]
+    },
+    {
+      title: "Bugfix",
+      fragmentEntries: [
+        "Update auth function to work properly when JWT is null"
+      ]
+    }
+  ];
+  expect(
+    generateTemplateData("0.0.2", "YYYY-MM-DD", fakeFragments)
+  ).toStrictEqual(mockData);
 });

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,4 +1,4 @@
-const { buildConfig } = require("../src/config");
+const { buildConfig, retrieveUserConfig } = require("../src/config");
 
 test("should return a base config", async () => {
   config = buildConfig({});
@@ -33,4 +33,21 @@ test.each([
   expect(() => {
     buildConfig(element);
   }).toThrowErrorMatchingSnapshot();
+});
+
+test("should retrieve user config info on package.json", () => {
+  const fakePjson = {
+    "release-it": {
+      plugins: {
+        xpto: {
+          foo: "bar"
+        }
+      }
+    }
+  };
+  expect(retrieveUserConfig(fakePjson, "xpto")).toStrictEqual({ foo: "bar" });
+});
+
+test("should return null when package.json doesnt have any configs", () => {
+  expect(retrieveUserConfig({}, null)).toBeNull();
 });

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -9,9 +9,9 @@ test("should return a base config", async () => {
   expect(config.changelogTemplate).toBe(`# [{{newVersion}}] - ({{bumpDate}})
 {{#fragments}}
 ## {{title}}
-{{#fragmentEntries}}
-* {{fragment}}
-{{/fragmentEntries}}
+{{#each fragmentEntries}}
+* {{this}}
+{{/each}}
 {{/fragments}}
 `);
   expect(config.fragmentsTypes).toEqual([

--- a/tests/file.test.js
+++ b/tests/file.test.js
@@ -4,7 +4,7 @@ const {
   deleteFragmentsFiles
 } = require("../src/file");
 
-const fs = require("fs");
+const fs = require("fs-extra");
 const mockFs = require("mock-fs");
 
 beforeEach(() => {

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -13,15 +13,17 @@ afterEach(() => {
 });
 
 test("should create a changelog file if doesnt exist", () => {
-  expect(fs.existsSync("virtual-env/CHANGELOG.md")).toBeFalsy();
-  checkChangelogFile("virtual-env/CHANGELOG.md");
-  expect(fs.existsSync("virtual-env/CHANGELOG.md")).toBeTruthy();
-  checkChangelogFile("virtual-env/CHANGELOG.md");
+  const FILE = "virtual-env/CHANGELOG.md";
+  expect(fs.existsSync(FILE)).toBeFalsy();
+  checkChangelogFile(FILE);
+  expect(fs.existsSync(FILE)).toBeTruthy();
+  checkChangelogFile(FILE);
 });
 
 test("should create a fragments folder with .gitkeep if doesnt exist", () => {
-  expect(fs.existsSync("virtual-env/fragments/.gitkeep")).toBeFalsy();
-  checkFragmentsFolder("virtual-env/fragments/.gitkeep");
-  expect(fs.existsSync("virtual-env/fragments/.gitkeep")).toBeTruthy();
-  checkFragmentsFolder("virtual-env/fragments/.gitkeep");
+  const FOLDER = "virtual-env/fragments/.gitkeep";
+  expect(fs.existsSync(FOLDER)).toBeFalsy();
+  checkFragmentsFolder(FOLDER);
+  expect(fs.existsSync(FOLDER)).toBeTruthy();
+  checkFragmentsFolder(FOLDER);
 });

--- a/tests/helpers.test.js
+++ b/tests/helpers.test.js
@@ -1,0 +1,27 @@
+const { checkChangelogFile, checkFragmentsFolder } = require("../src/helpers");
+const fs = require("fs-extra");
+const mockFs = require("mock-fs");
+
+beforeEach(() => {
+  mockFs({
+    "virtual-env": {}
+  });
+});
+
+afterEach(() => {
+  mockFs.restore();
+});
+
+test("should create a changelog file if doesnt exist", () => {
+  expect(fs.existsSync("virtual-env/CHANGELOG.md")).toBeFalsy();
+  checkChangelogFile("virtual-env/CHANGELOG.md");
+  expect(fs.existsSync("virtual-env/CHANGELOG.md")).toBeTruthy();
+  checkChangelogFile("virtual-env/CHANGELOG.md");
+});
+
+test("should create a fragments folder with .gitkeep if doesnt exist", () => {
+  expect(fs.existsSync("virtual-env/fragments/.gitkeep")).toBeFalsy();
+  checkFragmentsFolder("virtual-env/fragments/.gitkeep");
+  expect(fs.existsSync("virtual-env/fragments/.gitkeep")).toBeTruthy();
+  checkFragmentsFolder("virtual-env/fragments/.gitkeep");
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,9 +1,21 @@
 const { factory, runTasks } = require("release-it/test/util");
-const Plugin = require("../src");
+const mockFs = require("mock-fs");
+const Plugin = require("../src/index");
 const pjson = require("../package.json");
 const semver = require("semver");
 
 const namespace = "newsfragments";
+
+beforeEach(() => {
+  mockFs({
+    features: {},
+    "CHANGELOG.md": ""
+  });
+});
+
+afterEach(() => {
+  mockFs.restore();
+});
 
 test("should not throw errors and do a patch increase", async () => {
   const options = { [namespace]: {}, increment: "patch" };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,16 +1,23 @@
 const { factory, runTasks } = require("release-it/test/util");
+const fs = require("fs-extra");
 const mockFs = require("mock-fs");
+const moment = require("moment");
 const Plugin = require("../src/index");
 const pjson = require("../package.json");
 const semver = require("semver");
 
 const namespace = "newsfragments";
+let newsFragments;
 
 beforeEach(() => {
   mockFs({
-    features: {},
+    fragments: {
+      ".gitkeep": "",
+      "collect-me.feature": "Coleta com sucesso"
+    },
     "CHANGELOG.md": ""
   });
+  newsFragments = new Plugin();
 });
 
 afterEach(() => {
@@ -22,7 +29,34 @@ test("should not throw errors and do a patch increase", async () => {
   const plugin = factory(Plugin, { namespace, options });
   expect(await runTasks(plugin)).toStrictEqual({
     latestVersion: pjson.version,
-    name: "@grupoboticario/newsfragments",
+    name: "@grupoboticario/news-fragments",
     version: semver.inc(pjson.version, "patch")
   });
+});
+
+test("should collect a fragment when running init method", () => {
+  newsFragments.init();
+  expect(newsFragments.fragmentsToBurn).toStrictEqual([
+    { title: "Features", fragmentEntries: ["Coleta com sucesso"] }
+  ]);
+  expect(newsFragments.fragmentsToDelete).toStrictEqual([
+    "fragments/collect-me.feature"
+  ]);
+});
+
+test("should delete fragments when generated changelog", () => {
+  const version = pjson.version;
+  const date = moment().format("YYYY-MM-DD");
+  const expectedOutput = `# [${version}] - (${date})
+## Features
+* Coleta com sucesso
+`;
+  newsFragments.init();
+  newsFragments.afterRelease();
+  expect(
+    fs.readdirSync(newsFragments.baseConfig.fragmentsFolder)
+  ).toStrictEqual([".gitkeep"]);
+  expect(
+    fs.readFileSync(newsFragments.baseConfig.changelogFile, "utf8")
+  ).toStrictEqual(expectedOutput);
 });


### PR DESCRIPTION
- [x] Create a function to retrieve user config in `package.json`;
- [x] Create `init()` hook to prepare to generate the changelog file;
- [x] Create `afterRelease()` hook to generate the file and delete the used fragments.
- [x] Create fragments folder, if not exists, with .gitkeep file
- [x] Create changelog file if not exists