### PR TITLE
Fix broken CLI

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,7 +25,7 @@ import('meow').then(meow => {  // eslint-disable-line
     $ news-fragments preview -p 0.0.1
 `,
     {
-      importMeta: { url: pathToFileURL(__filename).toString() },
+      importMeta: import.meta,
       flags: {
         previousVersion: {
           type: "string",


### PR DESCRIPTION
Before:

```
(node:59495) UnhandledPromiseRejectionWarning: ReferenceError: __filename is not defined
    at file:///Users/dtinth/npmPackages/@spacet.me/chain/node_modules/.pnpm/news-fragments@1.15.1/node_modules/news-fragments/src/cli/index.js:28:40
(Use `node --trace-warnings ...` to show where the warning was created)
(node:59495) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:59495) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

After:

```
Fragment changes/1642157289290.misc created with success!
```