### PR TITLE
[ Proposal ] Updates documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,110 @@
    <img src="./changelog.png" alt="Logo" title="Logo" />
 </p>
 
-News fragments is a plugin for [release-it](https://github.com/release-it/release-it) that helps you to generate a changelog file.
+<p align="center">
+  <a href="https://www.npmjs.com/package/news-fragments?activeTab=versions"><img src="https://img.shields.io/npm/v/news-fragments?label=version&color=blue" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/news-fragments?activeTab=versions"><img src="https://img.shields.io/npm/dw/news-fragments?color=green" alt="weekly downloads" /></a>
+  <a href="https://www.npmjs.com/package/news-fragments?activeTab=versions"><img src="https://img.shields.io/npm/l/news-fragments" alt="license" /></a>
+</p>
 
-Basically, you need to specify a folder to be your center of fragments that will generate a custom changelog when released. After that, you'll create files with the desired extension with quick messages inside that folder to better understand what will come up on the new version of your software.
+News Fragments is a plugin for [release-it](https://github.com/release-it/release-it) that generates a changelog from small "fragment" files. During development, contributors add one fragment file per change; at release time the fragments are compiled into a versioned changelog entry and then deleted automatically.
 
 ## Requirements
 
-- Use Node v22+
+- Node v22+
+- npm v10+
+
+## Installation
+
+```bash
+npm install news-fragments
+```
 
 ## Setup
 
-In [release-it](https://github.com/release-it/release-it) config at `package.json`, create a `news-fragments` key-pair to override the default config - e.g.
+Add `news-fragments` as a plugin inside your [release-it](https://github.com/release-it/release-it) configuration in `package.json`:
 
 ```json
-"plugins": {
-  "news-fragments": {}
+{
+  "release-it": {
+    "plugins": {
+      "news-fragments": {}
+    }
+  }
 }
 ```
+
+Pass any [config options](#config-params) directly in this object to override the defaults.
+
+---
+
+## Release Workflow
+
+Follow these steps every time you need to publish a new version.
+
+### 1. Create fragment files during development
+
+For each change you want to appear in the changelog, run:
+
+```bash
+news-fragments create <fragment-type> "<description>"
+```
+
+**Available fragment types** (default): `feature`, `bugfix`, `doc`, `removal`, `misc`.
+
+Examples:
+
+```bash
+news-fragments create feature "Add dark mode support"
+news-fragments create bugfix "Fix race condition on login"
+news-fragments create misc "Update dependencies"
+```
+
+Each command creates a timestamped file inside the `fragments/` folder (e.g., `fragments/1714220400000.feature`). Commit these files together with the code changes they describe.
+
+### 2. Preview the next changelog entry
+
+Before releasing, verify what the generated changelog will look like:
+
+```bash
+news-fragments preview
+```
+
+To preview an already-released version stored in `CHANGELOG.md`:
+
+```bash
+news-fragments preview -p <version>
+# e.g. news-fragments preview -p 1.2.3
+```
+
+### 3. Run the release
+
+```bash
+npm run release
+```
+
+This command triggers `release-it`, which will:
+
+1. Run the test suite (`npm test`) as a pre-release check.
+2. Prompt you to select the next version (patch / minor / major).
+3. Burn the pending fragments into `CHANGELOG.md` under the new version header and delete the fragment files.
+4. Bump the version in `package.json`.
+5. Commit, tag, and push the release.
+
+> The burn step runs automatically via the `news-fragments` plugin — you do **not** need to run `news-fragments burn` manually when using `release-it`.
+
+### Manual burn (without release-it)
+
+If you need to compile fragments into the changelog outside of `release-it`, use:
+
+```bash
+news-fragments burn <version>
+# e.g. news-fragments burn 2.0.0
+```
+
+This writes the changelog entry for `<version>` and removes all consumed fragment files.
+
+---
 
 ## Config
 
@@ -28,21 +115,21 @@ In [release-it](https://github.com/release-it/release-it) config at `package.jso
 {
   "changelogFile": "CHANGELOG.md",
   "changelogDateFormat": "YYYY-MM-DD",
-  "changelogTemplate": changelogTemplate,
+  "changelogTemplate": "<built-in handlebars template>",
   "fragmentsFolder": "fragments",
   "fragmentsTypes": [
-    { "title": "Features", "extension": "feature" },
-    { "title": "Bugfixes", "extension": "bugfix" },
-    { "title": "Documentation", "extension": "doc" },
+    { "title": "Features",                  "extension": "feature" },
+    { "title": "Bugfixes",                  "extension": "bugfix"  },
+    { "title": "Documentation",             "extension": "doc"     },
     { "title": "Deprecations and Removals", "extension": "removal" },
-    { "title": "Misc", "extension": "misc" }
+    { "title": "Misc",                      "extension": "misc"    }
   ]
 }
 ```
 
 ### Default changelog template
 
-```
+```handlebars
 # [{{newVersion}}] - ({{bumpDate}})
 {{#fragments}}
 ## {{title}}
@@ -54,16 +141,39 @@ In [release-it](https://github.com/release-it/release-it) config at `package.jso
 
 ### Config params
 
-- **changelogFile**: A path to the file that will center your changelog.
-- **changelogDateFormat**: The date format that will be send to changelog template.
-- **changelogTemplate**: A [handlebars](https://www.npmjs.com/package/handlebars) template that will be used to render your changelog file content.
-- **fragmentsFolder**: A path to the folder that the fragments should be stored.
-- **fragmentsTypes**: An array containing a collection of objects with the title of changelog section and the extension of fragment types.
+| Key | Description |
+|-----|-------------|
+| `changelogFile` | Path to the changelog file. |
+| `changelogDateFormat` | [Moment.js](https://momentjs.com/docs/#/displaying/format/) date format used in the changelog header. |
+| `changelogTemplate` | A [Handlebars](https://handlebarsjs.com/) template string for each version block. |
+| `fragmentsFolder` | Path to the folder where fragment files are stored. |
+| `fragmentsTypes` | Array of `{ title, extension }` objects that define the supported fragment types and their changelog section headings. |
 
 > See this plugin in action by checking our [CHANGELOG.md](./CHANGELOG.md)
 
-## CLI
+---
+
+## CLI Reference
 
 ```bash
 news-fragments --help
+```
+
+| Command | Description |
+|---------|-------------|
+| `news-fragments create <type> "<text>"` | Create a new fragment file of the given type. |
+| `news-fragments preview` | Print the next changelog entry to the terminal. |
+| `news-fragments preview -p <version>` | Print a previously released changelog entry. |
+| `news-fragments burn <version>` | Compile fragments into the changelog and delete them. |
+
+---
+
+## Contributing
+
+```bash
+# Install dependencies
+npm install
+
+# Run tests (includes lint)
+npm test
 ```

--- a/fragments/1777317748961.doc
+++ b/fragments/1777317748961.doc
@@ -1,0 +1,1 @@
+Updates documentation.


### PR DESCRIPTION
This pull request significantly improves the `README.md` to provide clearer, more actionable documentation for users of the `news-fragments` plugin. The updates include better installation instructions, a step-by-step release workflow, improved configuration documentation, and a CLI reference. Additionally, a documentation fragment was added.

**Documentation improvements:**

* Expanded and clarified the introduction to explain the purpose and workflow of `news-fragments`.
* Added installation instructions and a detailed, step-by-step release workflow section, including examples for creating and previewing fragments.
* Improved configuration documentation: replaced prose with a table for config params, updated the default config and template examples, and clarified usage of Handlebars templates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R118) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R132) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R179)
* Added a CLI reference table and a new section on contributing to the project.

**Maintenance:**

* Added a new documentation fragment file `fragments/1777317748961.doc` to track these documentation updates.