### PR TITLE
misc: update dependencies

### DIFF
--- a/fragments/1782324296426.misc
+++ b/fragments/1782324296426.misc
@@ -1,0 +1,1 @@
+Update dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "news-fragments",
-  "version": "4.3.0",
+  "version": "4.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "news-fragments",
-      "version": "4.3.0",
+      "version": "4.4.2",
       "license": "Unlicense",
       "dependencies": {
         "chalk": "^5.6.2",
         "chalk-template": "^1.1.2",
         "handlebars": "^4.7.9",
-        "joi": "^18.1.2",
+        "joi": "^18.2.3",
         "markdown-it": "^14.2.0",
         "meow": "^14.1.0",
         "moment": "^2.30.1",
-        "release-it": "^20.0.1"
+        "release-it": "^20.2.0"
       },
       "bin": {
         "news-fragments": "src/cli/index.js"
@@ -24,21 +24,21 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
-        "@release-it/bumper": "^7.0.5",
-        "@vitest/coverage-v8": "^4.1.5",
-        "@vitest/ui": "^4.1.5",
-        "eslint": "^10.2.1",
+        "@release-it/bumper": "^7.0.6",
+        "@vitest/coverage-v8": "^4.1.9",
+        "@vitest/ui": "^4.1.9",
+        "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-prettier": "^5.5.5",
+        "eslint-plugin-prettier": "^5.5.6",
         "eslint-plugin-simple-import-sort": "^13.0.0",
         "fs-monkey": "^1.1.0",
-        "globals": "^17.5.0",
-        "memfs": "^4.57.2",
+        "globals": "^17.7.0",
+        "memfs": "^4.57.8",
         "mockdate": "^3.0.5",
-        "prettier": "^3.8.3",
+        "prettier": "^3.8.4",
         "pretty-quick": "^4.2.2",
-        "semver": "^7.7.4",
-        "vitest": "^4.1.5"
+        "semver": "^7.8.5",
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=22",
@@ -5292,15 +5292,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/release-it/node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5842,13 +5833,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -32,31 +32,34 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@release-it/bumper": "^7.0.5",
-    "@vitest/coverage-v8": "^4.1.5",
-    "@vitest/ui": "^4.1.5",
-    "eslint": "^10.2.1",
+    "@release-it/bumper": "^7.0.6",
+    "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/ui": "^4.1.9",
+    "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-prettier": "^5.5.6",
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "fs-monkey": "^1.1.0",
-    "globals": "^17.5.0",
-    "memfs": "^4.57.2",
+    "globals": "^17.7.0",
+    "memfs": "^4.57.8",
     "mockdate": "^3.0.5",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "pretty-quick": "^4.2.2",
-    "semver": "^7.7.4",
-    "vitest": "^4.1.5"
+    "semver": "^7.8.5",
+    "vitest": "^4.1.9"
   },
   "dependencies": {
     "chalk": "^5.6.2",
     "chalk-template": "^1.1.2",
     "handlebars": "^4.7.9",
-    "joi": "^18.1.2",
+    "joi": "^18.2.3",
     "markdown-it": "^14.2.0",
     "meow": "^14.1.0",
     "moment": "^2.30.1",
-    "release-it": "^20.0.1"
+    "release-it": "^20.2.0"
+  },
+  "overrides": {
+    "undici": "^8.5.0"
   },
   "engines": {
     "npm": ">=10",


### PR DESCRIPTION
This pull request focuses on updating project dependencies to their latest versions for improved stability, security, and compatibility. The updates affect both development and production dependencies, and an override for the `undici` package has been added.

Dependency updates:

* Updated several `devDependencies` in `package.json` to their latest versions, including `eslint`, `vitest`, `prettier`, and others.
* Updated several `dependencies` in `package.json`, such as `joi` and `release-it`.
* Added an `overrides` section to `package.json` to specify the minimum version for the `undici` package.

Miscellaneous:

* Added a note in `fragments/1782324296426.misc` documenting the dependency updates.